### PR TITLE
Migrate tests from rafeca/prettyjson

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # superprettyjson
 
-Format JSON data in a colored YAML-style, perfect for CLI output.
+Format JSON data in a colored YAML style, perfect for CLI output.
 
 ## Install
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -197,7 +197,7 @@ const renderToArray = (d, cfg, indentation) => {
 
     for (const element of data) {
       if (!isPrintable(element, cfg.renderUndefined)) {
-        return;
+        continue;
       }
 
       // Prepend the dash at the begining of each array's element line
@@ -243,7 +243,7 @@ const renderToArray = (d, cfg, indentation) => {
 
   for (const i of Object.getOwnPropertyNames(data)) {
     if (!isPrintable(data[i], cfg.renderUndefined)) {
-      return;
+      continue;
     }
 
     // Prepend the index at the beginning of the line

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Charlie Revett <superprettyjson@revdex.fastmail.com> (https://revcd.com)",
   "name": "superprettyjson",
-  "description": "Format JSON data in a colored YAML-style, perfect for CLI output",
+  "description": "Format JSON data in a colored YAML style, perfect for CLI output",
   "version": "1.3.0",
   "homepage": "http://github.com/revett/superprettyjson",
   "license": "MIT",
@@ -32,6 +32,7 @@
     "biome:check": "biome check .",
     "biome:fix": "biome check --write .",
     "test": "c8 --reporter=lcov --reporter=text-summary --reporter=text ava",
+    "test:watch": "ava --watch",
     "test:open-coverage-report": "open coverage/lcov-report/index.html",
     "test:ci": "ava --tap | tap-xunit > test-results.xml"
   },

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -9,7 +9,7 @@ const deepEqualMultiline = (t, output, expected) => {
   const outputLines = output.split("\n");
 
   const lastLine = outputLines[outputLines.length - 1];
-  if (lastLine === "") {
+  if (lastLine === "" && output.length > 1) {
     outputLines.pop();
   }
 

--- a/test/superprettyjson.test.js
+++ b/test/superprettyjson.test.js
@@ -264,7 +264,17 @@ test("render: null object", (t) => {
 });
 
 test("render: ignores undefined value", (t) => {
-  deepEqualMultiline(t, render(undefined), []);
+  deepEqualMultiline(t, render(undefined), [""]);
+});
+
+test("render: ignores undefined values in array", (t) => {
+  const input = [1, undefined, 2, undefined, 3];
+  const expected = [
+    `${colors.green("- ")}${colors.blue(1)}`,
+    `${colors.green("- ")}${colors.blue(2)}`,
+    `${colors.green("- ")}${colors.blue(3)}`,
+  ];
+  deepEqualMultiline(t, render(input), expected);
 });
 
 test("render: config.renderUndefined with standalone value", (t) => {
@@ -344,10 +354,19 @@ test("render: dates in object", (t) => {
   deepEqualMultiline(t, render(input), expected);
 });
 
-// TODO: Go over test titles
-// TODO: Group tests together that make sense
-// TODO: Make input data within all tests consistent
-// TODO: Move to table tests?
+test("renderString: empty string", (t) => {
+  t.is(renderString(""), "");
+});
+
+test("renderString: returns empty string if input not a string", (t) => {
+  t.is(renderString({}), "");
+});
+
+test("renderString: returns error on invalid JSON", (t) => {
+  const input = "not valid!!";
+  const expected = `${colors.red("Error:")} Not valid JSON!`;
+  t.is(renderString(input), expected);
+});
 
 test("renderString: valid JSON string", (t) => {
   const input = '{"test": "OK"}';
@@ -355,4 +374,20 @@ test("renderString: valid JSON string", (t) => {
   deepEqualMultiline(t, renderString(input), expected);
 });
 
-// TODO: Migrate other existing tests from test/prettyjson_spec.js for renderString()
+test("renderString: dismiss trailing characters which are not JSON", (t) => {
+  const input = `characters that are not JSON at all... {"test": "OK"}`;
+  const expected = ["characters that are not JSON at all... ", `${colors.green("test: ")}OK`];
+  deepEqualMultiline(t, renderString(input), expected);
+});
+
+test("renderString: dismiss trailing characters which are not JSON (array)", (t) => {
+  const input = `characters that are not JSON at all... ["test"]`;
+  const expected = ["characters that are not JSON at all... ", `${colors.green("- ")}test`];
+  deepEqualMultiline(t, renderString(input), expected);
+});
+
+test("renderString: accepts options parameter", (t) => {
+  const input = '{"test": "OK"}';
+  const expected = [`${colors.green("test: ")}${colors.red("OK")}`];
+  deepEqualMultiline(t, renderString(input, { stringColor: "red" }), expected);
+});

--- a/test/superprettyjson.test.js
+++ b/test/superprettyjson.test.js
@@ -1,51 +1,250 @@
 const test = require("ava");
 const colors = require("@colors/colors/safe");
 const { render, renderString } = require("../lib/superprettyjson");
+const { deepEqualMultiline } = require("./helpers");
 
 test("render: outputs string same as input", (t) => {
   const input = "This is a string";
-  t.is(render(input), input);
+  const expected = [input];
+  deepEqualMultiline(t, render(input), expected);
 });
 
 test("render: outputs string with indentation", (t) => {
   const input = "This is a string";
-  const expected = `    ${input}`;
-  t.is(render(input, {}, 4), expected);
+  const expected = [`    ${input}`];
+  deepEqualMultiline(t, render(input, {}, 4), expected);
 });
 
 test("render: outputs multiline string with indentation", (t) => {
   const input = "multiple\nlines";
-  const expected = `    """\n      multiple\n      lines\n    """`;
-  t.is(render(input, {}, 4), expected);
+  const expected = [`    """`, "      multiple", "      lines", `    """`];
+  deepEqualMultiline(t, render(input, {}, 4), expected);
 });
 
 test("render: outputs escaped string if have conflict chars", (t) => {
   const input = "#irchannel";
   const cfg = { escape: true };
-  const expected = `    "#irchannel"`;
-  t.is(render(input, cfg, 4), expected);
+  const expected = [`    "#irchannel"`];
+  deepEqualMultiline(t, render(input, cfg, 4), expected);
 });
 
 test("render: outputs array of strings", (t) => {
   const input = ["first string", "second string"];
-  const expected = [colors.green("- ") + input[0], colors.green("- ") + input[1]].join("\n");
-  t.is(render(input), expected);
+  const expected = [`${colors.green("- ")}${input[0]}`, `${colors.green("- ")}${input[1]}`];
+  deepEqualMultiline(t, render(input), expected);
 });
 
 test("render: outputs function", (t) => {
   const input = ["first string", (a) => a];
-  const expected = [`${colors.green("- ")}${input[0]}`, `${colors.green("- ")}function() {}`].join(
-    "\n",
-  );
-  t.is(render(input), expected);
+  const expected = [`${colors.green("- ")}${input[0]}`, `${colors.green("- ")}function() {}`];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: outputs array of arrays", (t) => {
+  const input = ["first string", ["nested 1", "nested 2"], "second string"];
+  const expected = [
+    `${colors.green("- ")}${input[0]}`,
+    `${colors.green("- ")}`,
+    `  ${colors.green("- ")}${input[1][0]}`,
+    `  ${colors.green("- ")}${input[1][1]}`,
+    `${colors.green("- ")}${input[2]}`,
+  ];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: outputs hash of strings", (t) => {
+  const input = { param1: "first string", param2: "second string" };
+  const expected = [
+    `${colors.green("param1: ")}${input.param1}`,
+    `${colors.green("param2: ")}${input.param2}`,
+  ];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: outputs hash of hashes", (t) => {
+  const input = {
+    firstParam: { subparam: "first string", subparam2: "another string" },
+    secondParam: "second string",
+  };
+  const expected = [
+    `${colors.green("firstParam: ")}`,
+    `  ${colors.green("subparam: ")} first string`,
+    `  ${colors.green("subparam2: ")}another string`,
+    `${colors.green("secondParam: ")}second string`,
+  ];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: outputs hash of strings with large keys", (t) => {
+  const input = { veryLargeParam: "first string", param: "second string" };
+  const expected = [
+    `${colors.green("veryLargeParam: ")}first string`,
+    `${colors.green("param: ")}         second string`,
+  ];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: outputs hash of strings with noAlign", (t) => {
+  const input = { veryLargeParam: "first string", param: "second string" };
+  const expected = [
+    `${colors.green("veryLargeParam: ")}first string`,
+    `${colors.green("param: ")}second string`,
+  ];
+  deepEqualMultiline(t, render(input, { noAlign: true }), expected);
+});
+
+test("render: outputs really nested object", (t) => {
+  const input = {
+    firstParam: {
+      subparam: "first string",
+      subparam2: "another string",
+      subparam3: ["different", "values", "in an array"],
+    },
+    secondParam: "second string",
+    anArray: [{ param3: "value", param10: "other value" }],
+    emptyArray: [],
+  };
+  const expected = [
+    `${colors.green("firstParam: ")}`,
+    `  ${colors.green("subparam: ")} first string`,
+    `  ${colors.green("subparam2: ")}another string`,
+    `  ${colors.green("subparam3: ")}`,
+    `    ${colors.green("- ")}different`,
+    `    ${colors.green("- ")}values`,
+    `    ${colors.green("- ")}in an array`,
+    `${colors.green("secondParam: ")}second string`,
+    `${colors.green("anArray: ")}`,
+    `  ${colors.green("- ")}`,
+    `    ${colors.green("param3: ")} value`,
+    `    ${colors.green("param10: ")}other value`,
+    `${colors.green("emptyArray: ")}`,
+    "  (empty array)",
+  ];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: outputs hash of strings with keysColor", (t) => {
+  const input = { param1: "first string", param2: "second string" };
+  const expected = [
+    `${colors.blue("param1: ")}first string`,
+    `${colors.blue("param2: ")}second string`,
+  ];
+  deepEqualMultiline(t, render(input, { keysColor: "blue" }), expected);
+});
+
+test("render: outputs hash of strings with numberColor", (t) => {
+  const input = { param1: 17, param2: 22.3 };
+  const expected = [
+    `${colors.green("param1: ")}${colors.red("17")}`,
+    `${colors.green("param2: ")}${colors.red("22.3")}`,
+  ];
+  deepEqualMultiline(t, render(input, { numberColor: "red" }), expected);
+});
+
+test("render: outputs hash of strings with positiveNumberColor", (t) => {
+  const input = { param1: 17, param2: -22.3 };
+  const expected = [
+    `${colors.green("param1: ")}${colors.red("17")}`,
+    `${colors.green("param2: ")}${colors.blue("-22.3")}`,
+  ];
+  deepEqualMultiline(t, render(input, { positiveNumberColor: "red" }), expected);
+});
+
+test("render: outputs hash of strings with negativeNumberColor", (t) => {
+  const input = { param1: 17, param2: -22.3 };
+  const expected = [
+    `${colors.green("param1: ")}${colors.blue("17")}`,
+    `${colors.green("param2: ")}${colors.red("-22.3")}`,
+  ];
+  deepEqualMultiline(t, render(input, { negativeNumberColor: "red" }), expected);
+});
+
+test("render: outputs hash of strings with rainbow keys", (t) => {
+  const input = { paramLong: "first string", param2: "second string" };
+  const expected = [
+    `${colors.rainbow("paramLong: ")}first string`,
+    `${colors.rainbow("param2: ")}   second string`,
+  ];
+  deepEqualMultiline(t, render(input, { keysColor: "rainbow" }), expected);
+});
+
+test("render: outputs hash of strings with defaultIndentation", (t) => {
+  const input = { param: ["first string", "second string"] };
+  const expected = [
+    `${colors.green("param: ")}`,
+    `    ${colors.green("- ")}first string`,
+    `    ${colors.green("- ")}second string`,
+  ];
+  deepEqualMultiline(t, render(input, { defaultIndentation: 4 }), expected);
+});
+
+test("render: outputs empty array with emptyArrayMsg", (t) => {
+  const input = [];
+  const expected = ["(empty)"];
+  deepEqualMultiline(t, render(input, { emptyArrayMsg: "(empty)" }), expected);
+});
+
+test("render: outputs hash of strings with stringColor", (t) => {
+  const input = { param1: "first string", param2: "second string" };
+  const expected = [
+    `${colors.blue("param1: ")}${colors.red("first string")}`,
+    `${colors.blue("param2: ")}${colors.red("second string")}`,
+  ];
+  deepEqualMultiline(t, render(input, { keysColor: "blue", stringColor: "red" }), expected);
+});
+
+test("render: outputs multiline string with multilineStringColor", (t) => {
+  const input = "first line string\nsecond line string";
+  const expected = [
+    `${colors.red('"""')}`,
+    `  ${colors.red("first line string")}`,
+    `  ${colors.red("second line string")}`,
+    `${colors.red('"""')}`,
+  ];
+  deepEqualMultiline(t, render(input, { multilineStringColor: "red" }), expected);
+});
+
+test("render: outputs hash of strings with noColor", (t) => {
+  const input = { param1: "first string", param2: "second string" };
+  const expected = ["param1: first string", "param2: second string"];
+  deepEqualMultiline(t, render(input, { noColor: true }), expected);
+});
+
+test("render: outputs hash of simple array with inlineArrays", (t) => {
+  const input = { installs: ["first string", "second string", false, 13] };
+  const expected = [`${colors.green("installs: ")}first string, second string, false, 13`];
+  deepEqualMultiline(t, render(input, { inlineArrays: true }), expected);
+});
+
+test("render: outputs hash of complex array with inlineArrays", (t) => {
+  const input = { installs: [["first string", "second string"], "third string"] };
+  const expected = [
+    `${colors.green("installs: ")}`,
+    `  ${colors.green("- ")}first string, second string`,
+    `  ${colors.green("- ")}third string`,
+  ];
+  deepEqualMultiline(t, render(input, { inlineArrays: true }), expected);
+});
+
+test("render: does not print an object prototype", (t) => {
+  const Input = function () {
+    this.param1 = "first string";
+    this.param2 = "second string";
+  };
+  Input.prototype = { randomProperty: "idontcare" };
+  const expected = [
+    `${colors.green("param1: ")}first string`,
+    `${colors.green("param2: ")}second string`,
+  ];
+  deepEqualMultiline(t, render(new Input()), expected);
 });
 
 // TODO: Migrate other existing tests from test/prettyjson_spec.js for render()
 
 test("renderString: works with valid JSON string", (t) => {
   const input = '{"test": "OK"}';
-  const expected = `${colors.green("test: ")}OK`;
-  t.is(renderString(input), expected);
+  const expected = [`${colors.green("test: ")}OK`];
+  deepEqualMultiline(t, renderString(input), expected);
 });
 
 // TODO: Migrate other existing tests from test/prettyjson_spec.js for renderString()

--- a/test/superprettyjson.test.js
+++ b/test/superprettyjson.test.js
@@ -75,7 +75,7 @@ test("render: nested object", (t) => {
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: correctly aligns largs object keys", (t) => {
+test("render: aligns largs object keys", (t) => {
   const input = { veryLargeParam: "first string", param: "second string" };
   const expected = [
     `${colors.green("veryLargeParam: ")}first string`,
@@ -263,7 +263,91 @@ test("render: null object", (t) => {
   deepEqualMultiline(t, render(input), expected);
 });
 
-// TODO: Migrate other existing tests from test/prettyjson_spec.js for render()
+test("render: ignores undefined value", (t) => {
+  deepEqualMultiline(t, render(undefined), []);
+});
+
+test("render: config.renderUndefined with standalone value", (t) => {
+  const expected = [colors.grey("undefined")];
+  deepEqualMultiline(t, render(undefined, { renderUndefined: true }), expected);
+});
+
+test("render: ignores undefined values within object", (t) => {
+  const input = {
+    foo: undefined,
+    bar: [1, undefined, 2],
+  };
+  const expected = [
+    `${colors.green("bar: ")}`,
+    `  ${colors.green("- ")}${colors.blue(1)}`,
+    `  ${colors.green("- ")}${colors.blue(2)}`,
+  ];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: config.renderUndefined with object", (t) => {
+  const input = {
+    foo: undefined,
+    bar: [1, undefined, 2],
+  };
+  const expected = [
+    `${colors.green("foo: ")}${colors.grey("undefined")}`,
+    `${colors.green("bar: ")}`,
+    `  ${colors.green("- ")}${colors.blue(1)}`,
+    `  ${colors.green("- ")}${colors.grey("undefined")}`,
+    `  ${colors.green("- ")}${colors.blue(2)}`,
+  ];
+  deepEqualMultiline(t, render(input, { renderUndefined: true }), expected);
+});
+
+test("render: Error", (t) => {
+  Error.stackTraceLimit = 1;
+  const input = new Error("foo");
+  const stack = input.stack.split("\n");
+  const expected = [
+    `${colors.green("message: ")}foo`,
+    `${colors.green("stack: ")}`,
+    `  ${colors.green("- ")}${stack[0]}`,
+    `  ${colors.green("- ")}${stack[1]}`,
+  ];
+  deepEqualMultiline(t, render(input, { noEscape: true }), expected);
+});
+
+test("render: serializable items in an array inline", (t) => {
+  const now = new Date();
+  const input = ["a", 3, null, true, undefined, false, now];
+  const expected = [
+    `${colors.green("- ")}a`,
+    `${colors.green("- ")}${colors.blue("3")}`,
+    `${colors.green("- ")}${colors.grey("null")}`,
+    `${colors.green("- ")}${colors.green("true")}`,
+    `${colors.green("- ")}${colors.red("false")}`,
+    `${colors.green("- ")}${now}`,
+  ];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: date", (t) => {
+  const input = new Date();
+  const expected = [input.toString()];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: dates in object", (t) => {
+  const today = new Date();
+  const tomorrow = new Date();
+  const input = { today, tomorrow };
+  const expected = [
+    `${colors.green("today: ")}   ${today.toString()}`,
+    `${colors.green("tomorrow: ")}${tomorrow.toString()}`,
+  ];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+// TODO: Go over test titles
+// TODO: Group tests together that make sense
+// TODO: Make input data within all tests consistent
+// TODO: Move to table tests?
 
 test("renderString: valid JSON string", (t) => {
   const input = '{"test": "OK"}';

--- a/test/superprettyjson.test.js
+++ b/test/superprettyjson.test.js
@@ -3,44 +3,44 @@ const colors = require("@colors/colors/safe");
 const { render, renderString } = require("../lib/superprettyjson");
 const { deepEqualMultiline } = require("./helpers");
 
-test("render: outputs string same as input", (t) => {
+test("render: string", (t) => {
   const input = "This is a string";
   const expected = [input];
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: outputs string with indentation", (t) => {
+test("render: string with indentation", (t) => {
   const input = "This is a string";
   const expected = [`    ${input}`];
   deepEqualMultiline(t, render(input, {}, 4), expected);
 });
 
-test("render: outputs multiline string with indentation", (t) => {
+test("render: multiline string with indentation", (t) => {
   const input = "multiple\nlines";
   const expected = [`    """`, "      multiple", "      lines", `    """`];
   deepEqualMultiline(t, render(input, {}, 4), expected);
 });
 
-test("render: outputs escaped string if have conflict chars", (t) => {
+test("render: handles escaped string with conflict chars", (t) => {
   const input = "#irchannel";
   const cfg = { escape: true };
   const expected = [`    "#irchannel"`];
   deepEqualMultiline(t, render(input, cfg, 4), expected);
 });
 
-test("render: outputs array of strings", (t) => {
+test("render: array", (t) => {
   const input = ["first string", "second string"];
   const expected = [`${colors.green("- ")}${input[0]}`, `${colors.green("- ")}${input[1]}`];
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: outputs function", (t) => {
+test("render: function", (t) => {
   const input = ["first string", (a) => a];
   const expected = [`${colors.green("- ")}${input[0]}`, `${colors.green("- ")}function() {}`];
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: outputs array of arrays", (t) => {
+test("render: nested array", (t) => {
   const input = ["first string", ["nested 1", "nested 2"], "second string"];
   const expected = [
     `${colors.green("- ")}${input[0]}`,
@@ -52,7 +52,7 @@ test("render: outputs array of arrays", (t) => {
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: outputs hash of strings", (t) => {
+test("render: object", (t) => {
   const input = { param1: "first string", param2: "second string" };
   const expected = [
     `${colors.green("param1: ")}${input.param1}`,
@@ -61,7 +61,7 @@ test("render: outputs hash of strings", (t) => {
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: outputs hash of hashes", (t) => {
+test("render: nested object", (t) => {
   const input = {
     firstParam: { subparam: "first string", subparam2: "another string" },
     secondParam: "second string",
@@ -75,7 +75,7 @@ test("render: outputs hash of hashes", (t) => {
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: outputs hash of strings with large keys", (t) => {
+test("render: correctly aligns largs object keys", (t) => {
   const input = { veryLargeParam: "first string", param: "second string" };
   const expected = [
     `${colors.green("veryLargeParam: ")}first string`,
@@ -84,7 +84,7 @@ test("render: outputs hash of strings with large keys", (t) => {
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: outputs hash of strings with noAlign", (t) => {
+test("render: respects noAlign", (t) => {
   const input = { veryLargeParam: "first string", param: "second string" };
   const expected = [
     `${colors.green("veryLargeParam: ")}first string`,
@@ -93,7 +93,7 @@ test("render: outputs hash of strings with noAlign", (t) => {
   deepEqualMultiline(t, render(input, { noAlign: true }), expected);
 });
 
-test("render: outputs really nested object", (t) => {
+test("render: complex nested object", (t) => {
   const input = {
     firstParam: {
       subparam: "first string",
@@ -123,7 +123,7 @@ test("render: outputs really nested object", (t) => {
   deepEqualMultiline(t, render(input), expected);
 });
 
-test("render: outputs hash of strings with keysColor", (t) => {
+test("render: respects keysColor", (t) => {
   const input = { param1: "first string", param2: "second string" };
   const expected = [
     `${colors.blue("param1: ")}first string`,
@@ -132,7 +132,7 @@ test("render: outputs hash of strings with keysColor", (t) => {
   deepEqualMultiline(t, render(input, { keysColor: "blue" }), expected);
 });
 
-test("render: outputs hash of strings with numberColor", (t) => {
+test("render: respects numberColor", (t) => {
   const input = { param1: 17, param2: 22.3 };
   const expected = [
     `${colors.green("param1: ")}${colors.red("17")}`,
@@ -141,7 +141,7 @@ test("render: outputs hash of strings with numberColor", (t) => {
   deepEqualMultiline(t, render(input, { numberColor: "red" }), expected);
 });
 
-test("render: outputs hash of strings with positiveNumberColor", (t) => {
+test("render: respects positiveNumberColor", (t) => {
   const input = { param1: 17, param2: -22.3 };
   const expected = [
     `${colors.green("param1: ")}${colors.red("17")}`,
@@ -150,7 +150,7 @@ test("render: outputs hash of strings with positiveNumberColor", (t) => {
   deepEqualMultiline(t, render(input, { positiveNumberColor: "red" }), expected);
 });
 
-test("render: outputs hash of strings with negativeNumberColor", (t) => {
+test("render: respects negativeNumberColor", (t) => {
   const input = { param1: 17, param2: -22.3 };
   const expected = [
     `${colors.green("param1: ")}${colors.blue("17")}`,
@@ -159,7 +159,7 @@ test("render: outputs hash of strings with negativeNumberColor", (t) => {
   deepEqualMultiline(t, render(input, { negativeNumberColor: "red" }), expected);
 });
 
-test("render: outputs hash of strings with rainbow keys", (t) => {
+test("render: outputs using rainbow keys color pattern", (t) => {
   const input = { paramLong: "first string", param2: "second string" };
   const expected = [
     `${colors.rainbow("paramLong: ")}first string`,
@@ -168,7 +168,7 @@ test("render: outputs hash of strings with rainbow keys", (t) => {
   deepEqualMultiline(t, render(input, { keysColor: "rainbow" }), expected);
 });
 
-test("render: outputs hash of strings with defaultIndentation", (t) => {
+test("render: respects defaultIndentation", (t) => {
   const input = { param: ["first string", "second string"] };
   const expected = [
     `${colors.green("param: ")}`,
@@ -178,22 +178,22 @@ test("render: outputs hash of strings with defaultIndentation", (t) => {
   deepEqualMultiline(t, render(input, { defaultIndentation: 4 }), expected);
 });
 
-test("render: outputs empty array with emptyArrayMsg", (t) => {
+test("render: respects emptyArrayMsg", (t) => {
   const input = [];
   const expected = ["(empty)"];
   deepEqualMultiline(t, render(input, { emptyArrayMsg: "(empty)" }), expected);
 });
 
-test("render: outputs hash of strings with stringColor", (t) => {
+test("render: respects stringColor", (t) => {
   const input = { param1: "first string", param2: "second string" };
   const expected = [
-    `${colors.blue("param1: ")}${colors.red("first string")}`,
-    `${colors.blue("param2: ")}${colors.red("second string")}`,
+    `${colors.green("param1: ")}${colors.red("first string")}`,
+    `${colors.green("param2: ")}${colors.red("second string")}`,
   ];
-  deepEqualMultiline(t, render(input, { keysColor: "blue", stringColor: "red" }), expected);
+  deepEqualMultiline(t, render(input, { stringColor: "red" }), expected);
 });
 
-test("render: outputs multiline string with multilineStringColor", (t) => {
+test("render: respects multilineStringColor", (t) => {
   const input = "first line string\nsecond line string";
   const expected = [
     `${colors.red('"""')}`,
@@ -204,19 +204,19 @@ test("render: outputs multiline string with multilineStringColor", (t) => {
   deepEqualMultiline(t, render(input, { multilineStringColor: "red" }), expected);
 });
 
-test("render: outputs hash of strings with noColor", (t) => {
+test("render: respects noColor", (t) => {
   const input = { param1: "first string", param2: "second string" };
   const expected = ["param1: first string", "param2: second string"];
   deepEqualMultiline(t, render(input, { noColor: true }), expected);
 });
 
-test("render: outputs hash of simple array with inlineArrays", (t) => {
+test("render: uses inlineArrays to output simple array", (t) => {
   const input = { installs: ["first string", "second string", false, 13] };
   const expected = [`${colors.green("installs: ")}first string, second string, false, 13`];
   deepEqualMultiline(t, render(input, { inlineArrays: true }), expected);
 });
 
-test("render: outputs hash of complex array with inlineArrays", (t) => {
+test("render: uses inlineArrays to output complex nested arrays", (t) => {
   const input = { installs: [["first string", "second string"], "third string"] };
   const expected = [
     `${colors.green("installs: ")}`,
@@ -226,7 +226,7 @@ test("render: outputs hash of complex array with inlineArrays", (t) => {
   deepEqualMultiline(t, render(input, { inlineArrays: true }), expected);
 });
 
-test("render: does not print an object prototype", (t) => {
+test("render: ignores object prototype", (t) => {
   const Input = function () {
     this.param1 = "first string";
     this.param2 = "second string";
@@ -239,9 +239,33 @@ test("render: does not print an object prototype", (t) => {
   deepEqualMultiline(t, render(new Input()), expected);
 });
 
+test("render: outputs number", (t) => {
+  const input = 12345;
+  const expected = [colors.blue("12345")];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: outputs truthy boolean", (t) => {
+  const input = true;
+  const expected = [colors.green("true")];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: falsy boolean", (t) => {
+  const input = false;
+  const expected = [colors.red("false")];
+  deepEqualMultiline(t, render(input), expected);
+});
+
+test("render: null object", (t) => {
+  const input = null;
+  const expected = [colors.grey("null")];
+  deepEqualMultiline(t, render(input), expected);
+});
+
 // TODO: Migrate other existing tests from test/prettyjson_spec.js for render()
 
-test("renderString: works with valid JSON string", (t) => {
+test("renderString: valid JSON string", (t) => {
   const input = '{"test": "OK"}';
   const expected = [`${colors.green("test: ")}OK`];
   deepEqualMultiline(t, renderString(input), expected);


### PR DESCRIPTION
- Original test suite had good coverage
- Migrate across to the new `ava` test structure